### PR TITLE
Integrate contract data with game page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -226,7 +226,7 @@ function AppContent() {
         }
       />
       <Route
-        path="/game/snakes-and-ladders"
+        path="/game/:roomId"
         element={<SnakesAndLaddersPage />}
       />
     </Routes>

--- a/src/features/Explore/ExplorePage.tsx
+++ b/src/features/Explore/ExplorePage.tsx
@@ -105,7 +105,8 @@ export default function ExplorePage({ handleButtonClick }: ExplorePageProps) {
 
   const handleRollClick = (game: Game) => {
     handleButtonClick();
-    navigate("/game/snakes-and-ladders", { state: { gameId: game.id } });
+    const id = game.id.split("#")[1];
+    navigate(`/game/${id}`);
   };
 
   // Trigger participation flow
@@ -133,11 +134,12 @@ export default function ExplorePage({ handleButtonClick }: ExplorePageProps) {
 
   // Navigate after successful participation
   useEffect(() => {
-    if (participateStep === "completed") {
+    if (participateStep === "completed" && selectedGame) {
       setIsConfirmJoinModalOpen(false);
-      navigate("/game/snakes-and-ladders");
+      const id = selectedGame.id.split("#")[1];
+      navigate(`/game/${id}`);
     }
-  }, [participateStep, navigate]);
+  }, [participateStep, navigate, selectedGame]);
 
   // Component to render game button with hasJoined check
   const GameButton = ({ game }: { game: Game }) => {


### PR DESCRIPTION
## Summary
- support dynamic game URLs using game room id
- navigate to the dynamic game page from the explore list
- load player data from the SnakeLadderGame contract on the board
- call `rollDice` on chain when rolling dice
- go back to explore when finishing a game

## Testing
- `npx --yes biome check src`

------
https://chatgpt.com/codex/tasks/task_e_684a8868d640832c8c8c9777376dc863