### PR TITLE
Allow viewing started games

### DIFF
--- a/src/features/Explore/ExplorePage.tsx
+++ b/src/features/Explore/ExplorePage.tsx
@@ -174,15 +174,16 @@ export default function ExplorePage({ handleButtonClick }: ExplorePageProps) {
           </button>
         );
       } else {
-        // User hasn't joined and game started - show disabled Started button
+        // User hasn't joined and game started - allow viewing the game
         return (
           <button
             type="button"
-            disabled
-            className="px-4 py-1 text-sm font-normal uppercase rounded-md border-2 transition-colors duration-300 
-                     text-gray-500 bg-gray-700 border-gray-600 cursor-not-allowed"
+            onClick={() => handleRollClick(game)}
+            className="px-4 py-1 text-sm font-normal uppercase rounded-md border-2 transition-colors duration-300
+                     text-[#2c1810] bg-gradient-to-r from-[#9ca3af] to-[#d1d5db] border-[#6b7280]
+                     hover:from-[#d1d5db] hover:to-[#9ca3af]"
           >
-            Started
+            View
           </button>
         );
       }

--- a/src/features/SnakesAndLadders/SnakesAndLaddersPage.tsx
+++ b/src/features/SnakesAndLadders/SnakesAndLaddersPage.tsx
@@ -74,7 +74,7 @@ const PlayerCorner: React.FC<{
 
   const diceBox = (
     <div className="w-12 h-12 border-2 border-[#8b4513] rounded-lg flex items-center justify-center bg-[#2c1810]">
-      {isCurrent && !winner && (
+      {isCurrent && isSelf && !winner && (
         <Dice
           onRollComplete={handleDiceRollComplete}
           isParentRolling={isRolling}


### PR DESCRIPTION
## Summary
- show `View` button when a started game is not joined
- restrict dice rolling to the active player only

## Testing
- `yarn lint` *(fails: Alternative text title element cannot be empty)*

------
https://chatgpt.com/codex/tasks/task_e_684b96c506bc832c91c09a3721d6745b