### PR TITLE
Fix dice rolling flow

### DIFF
--- a/src/components/Dice/Dice.tsx
+++ b/src/components/Dice/Dice.tsx
@@ -87,7 +87,8 @@ const Dice: React.FC<DiceProps> = ({
     setTimeout(() => {
       setCurrentDisplayValue(roll);
       onRollCompleteRef.current(roll);
-      setParentIsRolling(false); // Set rolling to false after completion
+      // Parent component will decide when to stop rolling, typically after
+      // transaction confirmation.
     }, 1500);
   }, [isParentRolling, setParentIsRolling, playSound, styles, disabled]); // Added styles to dependency array
 


### PR DESCRIPTION
## Summary
- ensure dice keeps rolled value until transaction confirmation
- reset dice when turn changes
- wait for dice roll transaction before enabling next move

## Testing
- `npx biome check src` *(fails: Found 96 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684be05d5ae4832ca03b45f1433a43b6