### PR TITLE
Add player profile view with stats

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import HomePage from "./features/Home/HomePage";
 import SnakesAndLaddersPage from "./features/SnakesAndLadders/SnakesAndLaddersPage";
 import CreateGamePage from "./features/CreateGame/CreateGamePage";
 import LeaderboardPage from "./features/Leaderboard/LeaderboardPage";
+import PlayerProfilePage from "./features/Profile/PlayerProfilePage";
 import "./styles/global.css";
 import type { SDKUser } from "./types";
 
@@ -230,6 +231,10 @@ function AppContent() {
         path="/leaderboard"
         element={<LeaderboardPage handleButtonClick={handleButtonClick} />}
       />
+      <Route
+        path="/profile/:address"
+        element={<PlayerProfilePage handleButtonClick={handleButtonClick} />}
+      />
       <Route path="/game/:roomId" element={<SnakesAndLaddersPage />} />
     </Routes>
   );
@@ -255,7 +260,9 @@ function AppContent() {
               ? "Create"
               : location.pathname === "/leaderboard"
                 ? "Leaderboard"
-                : "Mystic Paths"
+                : location.pathname.startsWith("/profile")
+                  ? "Profile"
+                  : "Mystic Paths"
         }
       >
         {routeContent}

--- a/src/components/Modal/ProfileModal.tsx
+++ b/src/components/Modal/ProfileModal.tsx
@@ -2,6 +2,7 @@ import type { SDKUser } from "../../types";
 import { useAccount } from "wagmi";
 import { useState } from "react";
 import { useFarcasterProfiles } from "../../hooks/useFarcasterProfiles";
+import usePlayerStats from "../../hooks/usePlayerStats";
 
 interface ProfileModalProps {
   isOpen: boolean;
@@ -20,6 +21,7 @@ export default function ProfileModal({
     address ? [address] : []
   );
   const walletProfile = address ? fcProfiles[address] : null;
+  const { gamesPlayed, wins, loading } = usePlayerStats(address ?? "");
   const [isCopied, setIsCopied] = useState(false);
 
   if (!isOpen) return null;
@@ -138,12 +140,24 @@ export default function ProfileModal({
 
             <div className="bg-[#1a0f09] rounded-lg p-2.5 shadow-inner">
               <p className="text-[#ffd700] text-xs mb-1">Games Played</p>
-              <p>0</p>
+              <p>
+                {address
+                  ? loading
+                    ? "Loading..."
+                    : gamesPlayed
+                  : "Not Connected"}
+              </p>
             </div>
 
             <div className="bg-[#1a0f09] rounded-lg p-2.5 shadow-inner">
               <p className="text-[#ffd700] text-xs mb-1">Total Wins</p>
-              <p>0</p>
+              <p>
+                {address
+                  ? loading
+                    ? "Loading..."
+                    : wins
+                  : "Not Connected"}
+              </p>
             </div>
           </div>
 

--- a/src/features/Explore/ExplorePage.tsx
+++ b/src/features/Explore/ExplorePage.tsx
@@ -215,6 +215,7 @@ export default function ExplorePage({ handleButtonClick }: ExplorePageProps) {
               game={game}
               onJoinClick={handleJoinQuestClick}
               farcasterProfiles={farcasterProfiles}
+              handleButtonClick={handleButtonClick}
             />
           ))}
         </div>
@@ -386,10 +387,12 @@ const GameCard = ({
   game,
   onJoinClick,
   farcasterProfiles,
+  handleButtonClick,
 }: {
   game: Game;
   onJoinClick: (game: Game) => void;
   farcasterProfiles: Record<string, any>;
+  handleButtonClick: () => void;
 }) => {
   const { metadata } = useGameMetadata(game.metadataUri);
   const { address, isConnected } = useAccount();
@@ -526,7 +529,19 @@ const GameCard = ({
         </div>
         <span className="text-sm">Prize: {game.prize.toFixed(2)} USD</span>
       </div>
-      <p className="text-sm mb-1">Creator: {creatorDisplayName}</p>
+      <p className="text-sm mb-1">
+        Creator:{" "}
+        <button
+          type="button"
+          onClick={() => {
+            handleButtonClick();
+            navigate(`/profile/${game.creator}`);
+          }}
+          className="underline hover:text-[#ffd700]"
+        >
+          {creatorDisplayName}
+        </button>
+      </p>
       <p className="text-xs text-gray-400 mb-1">
         Players: {game.players.length}/{game.requiredParticipants} required
       </p>
@@ -549,13 +564,21 @@ const GameCard = ({
                 const username = profile?.username ?? player;
 
                 return (
-                  <img
+                  <button
                     key={pIndex}
-                    src={pfpUrl}
-                    alt={username}
-                    title={username}
-                    className="w-8 h-8 rounded-full border-2 border-[#8b4513] object-cover bg-gray-700 hover:z-10 transform hover:scale-110 transition-transform"
-                  />
+                    type="button"
+                    onClick={() => {
+                      handleButtonClick();
+                      navigate(`/profile/${player}`);
+                    }}
+                  >
+                    <img
+                      src={pfpUrl}
+                      alt={username}
+                      title={username}
+                      className="w-8 h-8 rounded-full border-2 border-[#8b4513] object-cover bg-gray-700 hover:z-10 transform hover:scale-110 transition-transform"
+                    />
+                  </button>
                 );
               })}
               {game.players.length > 4 && (

--- a/src/features/Leaderboard/LeaderboardPage.tsx
+++ b/src/features/Leaderboard/LeaderboardPage.tsx
@@ -72,7 +72,10 @@ export default function LeaderboardPage({
         <div
           key={row.rank}
           className="bg-[#1a0f09] border-2 border-[#8b4513] rounded-lg px-2 py-2 text-white text-left shadow-md flex items-center justify-between hover:bg-[#8b4513]/20 transition-colors cursor-pointer"
-          onClick={handleButtonClick}
+          onClick={() => {
+            handleButtonClick();
+            navigate(`/profile/${row.address}`);
+          }}
         >
           <div className="flex items-center gap-3">
             <span className="font-bold text-2xl text-[#ffd700] w-8 text-center">

--- a/src/features/Profile/PlayerProfilePage.tsx
+++ b/src/features/Profile/PlayerProfilePage.tsx
@@ -1,0 +1,65 @@
+import { useParams, useNavigate } from "react-router-dom";
+import usePlayerStats from "../../hooks/usePlayerStats";
+import { useFarcasterProfiles } from "../../hooks/useFarcasterProfiles";
+
+interface PlayerProfilePageProps {
+  handleButtonClick: () => void;
+}
+
+export default function PlayerProfilePage({
+  handleButtonClick,
+}: PlayerProfilePageProps) {
+  const { address = "" } = useParams<{ address: string }>();
+  const navigate = useNavigate();
+  const { profiles } = useFarcasterProfiles([address]);
+  const profile = profiles[address];
+  const { gamesPlayed, wins, loading } = usePlayerStats(address);
+
+  const avatarUrl =
+    profile?.pfp?.url ||
+    `https://api.dicebear.com/7.x/avataaars/svg?seed=${address}`;
+  const displayName =
+    profile?.username || profile?.displayName || address;
+
+  return (
+    <div className="mx-auto mt-4 max-w-sm text-center space-y-6 pb-20">
+      <div className="flex flex-col items-center space-y-3">
+        <img
+          src={avatarUrl}
+          alt={displayName}
+          className="w-24 h-24 rounded-full border-2 border-[#8b4513] object-cover"
+        />
+        <h2 className="text-2xl text-[#ffd700] font-semibold">{displayName}</h2>
+        {profile?.bio?.text && (
+          <p className="text-sm text-gray-300">{profile.bio.text}</p>
+        )}
+      </div>
+      <div className="bg-[#1a0f09] border-2 border-[#8b4513] rounded-lg p-4 text-white space-y-1">
+        {loading ? (
+          <p>Loading stats...</p>
+        ) : (
+          <>
+            <p>
+              Games Played:{" "}
+              <span className="text-[#ffd700] font-semibold">{gamesPlayed}</span>
+            </p>
+            <p>
+              Wins:{" "}
+              <span className="text-[#ffd700] font-semibold">{wins}</span>
+            </p>
+          </>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={() => {
+          handleButtonClick();
+          navigate(-1);
+        }}
+        className="px-6 py-2 text-sm font-normal text-[#2c1810] uppercase rounded-md bg-gradient-to-r from-[#ffd700] to-[#ff8c00] border-2 border-[#8b4513] shadow-lg hover:from-[#ffed4a] hover:to-[#ffa500]"
+      >
+        Back
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/usePlayerStats.ts
+++ b/src/hooks/usePlayerStats.ts
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+import { usePublicClient } from "wagmi";
+import snakeGameContractInfo from "../constants/snakeGameContractInfo.json";
+
+interface PlayerStats {
+  gamesPlayed: number;
+  wins: number;
+  loading: boolean;
+}
+
+export default function usePlayerStats(address: string): PlayerStats {
+  const [gamesPlayed, setGamesPlayed] = useState(0);
+  const [wins, setWins] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const publicClient = usePublicClient();
+
+  useEffect(() => {
+    if (!address) return;
+    let cancelled = false;
+    const fetchStats = async () => {
+      setLoading(true);
+      try {
+        const lastRoomId = (await publicClient.readContract({
+          address: snakeGameContractInfo.address as `0x${string}`,
+          abi: snakeGameContractInfo.abi,
+          functionName: "getLastRoomId",
+        })) as bigint;
+
+        let played = 0;
+        let won = 0;
+        for (let i = 1; i <= Number(lastRoomId); i++) {
+          const players = (await publicClient.readContract({
+            address: snakeGameContractInfo.address as `0x${string}`,
+            abi: snakeGameContractInfo.abi,
+            functionName: "getRoomPlayers",
+            args: [BigInt(i)],
+          })) as string[];
+
+          if (players.some((p) => p.toLowerCase() === address.toLowerCase())) {
+            played++;
+            const info = (await publicClient.readContract({
+              address: snakeGameContractInfo.address as `0x${string}`,
+              abi: snakeGameContractInfo.abi,
+              functionName: "getRoomInfo",
+              args: [BigInt(i)],
+            })) as any[];
+            const winner = info[6] as string;
+            if (winner.toLowerCase() === address.toLowerCase()) {
+              won++;
+            }
+          }
+        }
+
+        if (!cancelled) {
+          setGamesPlayed(played);
+          setWins(won);
+        }
+      } catch (err) {
+        console.error("Failed to fetch player stats", err);
+        if (!cancelled) {
+          setGamesPlayed(0);
+          setWins(0);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchStats();
+    return () => {
+      cancelled = true;
+    };
+  }, [address, publicClient]);
+
+  return { gamesPlayed, wins, loading };
+}


### PR DESCRIPTION
## Summary
- add a `usePlayerStats` hook to fetch games played and wins
- create `PlayerProfilePage` displaying Farcaster info and stats
- link Explore game cards and leaderboard rows to profile page
- add `/profile/:address` route and update page title

## Testing
- `npx -y biome@latest check src --reporter terse`

------
https://chatgpt.com/codex/tasks/task_e_6851b66390e8832c8a88c2280f728839