### PR TITLE
Add view hooks for user data

### DIFF
--- a/src/components/Modal/ProfileModal.tsx
+++ b/src/components/Modal/ProfileModal.tsx
@@ -2,7 +2,7 @@ import type { SDKUser } from "../../types";
 import { useAccount } from "wagmi";
 import { useState } from "react";
 import { useFarcasterProfiles } from "../../hooks/useFarcasterProfiles";
-import usePlayerStats from "../../hooks/usePlayerStats";
+import useUserStats from "../../hooks/useUserStats";
 
 interface ProfileModalProps {
   isOpen: boolean;
@@ -21,7 +21,7 @@ export default function ProfileModal({
     address ? [address] : []
   );
   const walletProfile = address ? fcProfiles[address] : null;
-  const { gamesPlayed, wins, loading } = usePlayerStats(address ?? "");
+  const { gamesPlayed, wins, loading } = useUserStats(address ?? "");
   const [isCopied, setIsCopied] = useState(false);
 
   if (!isOpen) return null;

--- a/src/constants/snakeGameContractInfo.json
+++ b/src/constants/snakeGameContractInfo.json
@@ -551,6 +551,54 @@
     {
       "inputs": [
         {
+          "internalType": "address",
+          "name": "player",
+          "type": "address"
+        }
+      ],
+      "name": "getUserStats",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "totalGames",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "totalWins",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "rank",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "player",
+          "type": "address"
+        }
+      ],
+      "name": "getUserRooms",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
           "internalType": "uint256",
           "name": "roomId",
           "type": "uint256"

--- a/src/features/Explore/ExplorePage.tsx
+++ b/src/features/Explore/ExplorePage.tsx
@@ -7,6 +7,7 @@ import { useParticipate } from "../../hooks/useParticipate";
 import { useGameMetadata } from "../../hooks/useGameMetadata";
 import snakeGameContractInfo from "../../constants/snakeGameContractInfo.json";
 import { useFarcasterProfiles } from "../../hooks/useFarcasterProfiles";
+import useUserRooms from "../../hooks/useUserRooms";
 
 interface Game {
   id: string;
@@ -29,6 +30,7 @@ interface ExplorePageProps {
 export default function ExplorePage({ handleButtonClick }: ExplorePageProps) {
   const navigate = useNavigate();
   const { address } = useAccount();
+  const { roomIds: joinedRoomIds } = useUserRooms(address ?? "");
   const [activeTab, setActiveTab] = useState("all");
   const [searchParams, setSearchParams] = useSearchParams();
   const [selectedGame, setSelectedGame] = useState<Game | null>(null);
@@ -160,12 +162,13 @@ export default function ExplorePage({ handleButtonClick }: ExplorePageProps) {
   // Filter games based on activeTab and user participation
   const filteredGames = useMemo(() => {
     if (activeTab === "joined") {
-      return games.filter((game) =>
-        address ? game.players.includes(address) : false
-      );
+      return games.filter((game) => {
+        const idNum = Number(game.id.split("#")[1]);
+        return joinedRoomIds.includes(idNum);
+      });
     }
     return games;
-  }, [activeTab, games, address]);
+  }, [activeTab, games, joinedRoomIds]);
 
   // Show error state if there's a critical error
   if (error && games.length === 0 && !isLoading) {

--- a/src/features/Profile/PlayerProfilePage.tsx
+++ b/src/features/Profile/PlayerProfilePage.tsx
@@ -1,5 +1,5 @@
 import { useParams, useNavigate } from "react-router-dom";
-import usePlayerStats from "../../hooks/usePlayerStats";
+import useUserStats from "../../hooks/useUserStats";
 import { useFarcasterProfiles } from "../../hooks/useFarcasterProfiles";
 
 interface PlayerProfilePageProps {
@@ -13,7 +13,7 @@ export default function PlayerProfilePage({
   const navigate = useNavigate();
   const { profiles } = useFarcasterProfiles([address]);
   const profile = profiles[address];
-  const { gamesPlayed, wins, loading } = usePlayerStats(address);
+  const { gamesPlayed, wins, loading } = useUserStats(address);
 
   const avatarUrl =
     profile?.pfp?.url ||

--- a/src/hooks/useUserRooms.ts
+++ b/src/hooks/useUserRooms.ts
@@ -1,0 +1,16 @@
+import { useReadContract } from "wagmi";
+import snakeGameContractInfo from "../constants/snakeGameContractInfo.json";
+
+export default function useUserRooms(address: string) {
+  const { data, isLoading } = useReadContract({
+    address: snakeGameContractInfo.address as `0x${string}`,
+    abi: snakeGameContractInfo.abi,
+    functionName: "getUserRooms",
+    args: [address as `0x${string}`],
+    enabled: !!address,
+  });
+
+  const roomIds = data ? (data as bigint[]).map((id) => Number(id)) : [];
+
+  return { roomIds, isLoading };
+}

--- a/src/hooks/useUserStats.ts
+++ b/src/hooks/useUserStats.ts
@@ -1,0 +1,25 @@
+import { useReadContract } from "wagmi";
+import snakeGameContractInfo from "../constants/snakeGameContractInfo.json";
+
+export default function useUserStats(address: string) {
+  const { data, isLoading } = useReadContract({
+    address: snakeGameContractInfo.address as `0x${string}`,
+    abi: snakeGameContractInfo.abi,
+    functionName: "getUserStats",
+    args: [address as `0x${string}`],
+    enabled: !!address,
+  });
+
+  let gamesPlayed = 0;
+  let wins = 0;
+  let rank = 0;
+
+  if (data) {
+    const [totalGames, totalWins, playerRank] = data as [bigint, bigint, bigint];
+    gamesPlayed = Number(totalGames);
+    wins = Number(totalWins);
+    rank = Number(playerRank);
+  }
+
+  return { gamesPlayed, wins, rank, loading: isLoading };
+}


### PR DESCRIPTION
## Summary
- add hooks to read user stats and joined rooms
- show joined rooms using `getUserRooms` hook in Explore page
- switch profile components to use `getUserStats`
- extend ABI with `getUserStats` and `getUserRooms`

## Testing
- `npx hardhat test` *(fails: needs hardhat installation)*
- `npm run lint` *(fails: biome not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543c8516a0832c91cb0aec598250e1